### PR TITLE
非同期フェッチの修正

### DIFF
--- a/UBICoreData/NSManagedObject+UBICoreData.m
+++ b/UBICoreData/NSManagedObject+UBICoreData.m
@@ -186,14 +186,13 @@ NS_ASSUME_NONNULL_BEGIN
         }
         
         [bgRequest setResultType:NSManagedObjectIDResultType];
-        [bgRequest setSortDescriptors:nil];
         
         NSError *bgError = nil;
-        NSArray<__kindof NSManagedObject *> *bgObjects = [bgContext executeFetchRequest:bgRequest error:&bgError];
+        NSArray *objectIDs = [bgContext executeFetchRequest:bgRequest error:&bgError];
         
         [context performBlock:^{
             NSError *error = nil;
-            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF IN %@", bgObjects];
+            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF IN %@", objectIDs];
             NSFetchRequest *request	= [NSFetchRequest fetchRequestWithEntity:[self class] context:context];
             
             if (block) {

--- a/UBICoreDataTest/UBICoreDataTestTests/NSManagedObject+UBICoreDataTests.m
+++ b/UBICoreDataTest/UBICoreDataTestTests/NSManagedObject+UBICoreDataTests.m
@@ -301,11 +301,16 @@
 {
     UBICoreDataStore *dataStore = [UBICoreDataTestUtils createTestDataStore];
     Parent *parent1 = [Parent insertInContext:dataStore.mainContext];
-    Parent *parent2 = [Parent insertInContext:dataStore.mainContext];
+    Parent *parent5 = [Parent insertInContext:dataStore.mainContext];
     Parent *parent3 = [Parent insertInContext:dataStore.mainContext];
+    Parent *parent4 = [Parent insertInContext:dataStore.mainContext];
+    Parent *parent2 = [Parent insertInContext:dataStore.mainContext];
+    
     parent1.name = @"1";
-    parent2.name = @"2";
+    parent5.name = @"5";
     parent3.name = @"3";
+    parent4.name = @"4";
+    parent2.name = @"2";
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"fetch completion"];
     
@@ -314,8 +319,9 @@
         [request sortByKey:@"name" ascending:NO];
     } completion:^(NSArray<__kindof NSManagedObject *> * _Nonnull objects) {
         XCTAssertEqual(objects.count, 2);
-        XCTAssertEqualObjects([objects[0] name], @"3");
-        XCTAssertEqualObjects([objects[1] name], @"2");
+        
+        XCTAssertEqualObjects([objects[0] name], @"5");
+        XCTAssertEqualObjects([objects[1] name], @"4");
         
         [expectation fulfill];
     }];

--- a/UBICoreDataTest/UBICoreDataTestTests/NSManagedObject+UBICoreDataTests.m
+++ b/UBICoreDataTest/UBICoreDataTestTests/NSManagedObject+UBICoreDataTests.m
@@ -297,6 +297,32 @@
     [self waitForExpectationsWithTimeout:1.0 handler:NULL];
 }
 
+- (void)testFetchAsynchronouslyWithFetchLimitAndSort
+{
+    UBICoreDataStore *dataStore = [UBICoreDataTestUtils createTestDataStore];
+    Parent *parent1 = [Parent insertInContext:dataStore.mainContext];
+    Parent *parent2 = [Parent insertInContext:dataStore.mainContext];
+    Parent *parent3 = [Parent insertInContext:dataStore.mainContext];
+    parent1.name = @"1";
+    parent2.name = @"2";
+    parent3.name = @"3";
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"fetch completion"];
+    
+    [Parent fetchAsynchronouslyToContext:dataStore.mainContext request:^(NSFetchRequest * _Nonnull request, NSManagedObjectContext * _Nonnull context) {
+        request.fetchLimit = 2;
+        [request sortByKey:@"name" ascending:NO];
+    } completion:^(NSArray<__kindof NSManagedObject *> * _Nonnull objects) {
+        XCTAssertEqual(objects.count, 2);
+        XCTAssertEqualObjects([objects[0] name], @"3");
+        XCTAssertEqualObjects([objects[1] name], @"2");
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1.0 handler:NULL];
+}
+
 - (void)testIsCommitted
 {
     UBICoreDataStore *dataStore = [UBICoreDataTestUtils createTestDataStore];


### PR DESCRIPTION
非同期フェッチを行う`fetchAsynchronouslyToContext:`で、`fetchLimit`と`sortDescriptor`を`request`にセットした場合に順番がおかしい問題を修正。
